### PR TITLE
chore/ci: update travis.yml to include code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ os:
   - linux
 language: rust
 sudo: false
+addons:
+    apt:
+        packages:
+            - libssl-dev
 cache:
   cargo: true
 before_script:
@@ -19,3 +23,11 @@ script:
   - cargo test --verbose --release
 before_cache:
   - cargo prune
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    cargo install cargo-tarpaulin -f
+  fi
+after_success: |
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    # Uncomment the following line for coveralls.io
+    cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+  fi


### PR DESCRIPTION
Update .travis.yml file to install cargo-tarpaulin to gather code
coverage stats, then push results to coveralls.io.